### PR TITLE
Fixing getInfo()'s regex for name

### DIFF
--- a/twitter.gt2eb.user.js
+++ b/twitter.gt2eb.user.js
@@ -117,7 +117,7 @@
       bannerUrl:  x(/profile_banner_url\":\"(.+?)\",/),
       avatarUrl:  x(/profile_image_url_https\":\"(.+?)\",/, defaultAvatarUrl),
       screenName: x(/screen_name\":\"(.+?)\",/, "youarenotloggedin"),
-      name:       x(/(?:true|false),\"name\":\"(.+?)\",/, x(/screen_name\":\"(.+?)\",/, "Anonymous")),
+      name:       x(/,\"name\":\"(.+?)\",/, x(/screen_name\":\"(.+?)\",/, "Anonymous")),
       id:         x(/id_str\":\"(\d+)\"/, "0"),
       stats: {
         tweets:    parseInt(x(/statuses_count\":(\d+),/, "0")),


### PR DESCRIPTION
Modified [L120](https://github.com/Bl4Cc4t/GoodTwitter2/blob/97e7c1076836953ba14e4b92f93299270994fd02/twitter.gt2eb.user.js#L120) removing `(?:true|false)` in the regex, since the previous text on my own infoScript is `"media_count":xxx,`.

This fixes screen_name showing on the left-side user profile panel, instead of the actual name. Tested this on my own account, I don't know if infoScript heavily changes through accounts though.